### PR TITLE
Add create command

### DIFF
--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -1,0 +1,30 @@
+use anyhow::bail;
+use dialoguer::FuzzySelect;
+use dialoguer::theme::ColorfulTheme;
+use crate::ssm::Ssm;
+
+pub struct Param {
+    pub name: String,
+    pub value: String,
+}
+
+pub async fn select_param_value(ssm: &Ssm) -> anyhow::Result<Param> {
+    let mut parameter_names = ssm.get_parameter_names().await?;
+
+    if parameter_names.is_empty() {
+        bail!("no parameters found -- is your region configured?");
+    }
+
+    let selected_index = FuzzySelect::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select parameter (type for fuzzy search):")
+        .max_length(10)
+        .items(&parameter_names)
+        .interact()
+        .unwrap();
+
+    let value = ssm
+        .get_parameter_value(&parameter_names[selected_index])
+        .await?;
+
+    Ok(Param { name: parameter_names.remove(selected_index), value}, )
+}

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -1,12 +1,8 @@
-use anyhow::bail;
-use dialoguer::FuzzySelect;
-use dialoguer::theme::ColorfulTheme;
+use crate::param::Param;
 use crate::ssm::Ssm;
-
-pub struct Param {
-    pub name: String,
-    pub value: String,
-}
+use anyhow::bail;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::FuzzySelect;
 
 pub async fn select_param_value(ssm: &Ssm) -> anyhow::Result<Param> {
     let mut parameter_names = ssm.get_parameter_names().await?;
@@ -26,5 +22,5 @@ pub async fn select_param_value(ssm: &Ssm) -> anyhow::Result<Param> {
         .get_parameter_value(&parameter_names[selected_index])
         .await?;
 
-    Ok(Param { name: parameter_names.remove(selected_index), value}, )
+    Ok(Param::new(parameter_names.remove(selected_index), value))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,10 @@ async fn main() -> Result<()> {
                     .with_context(|| format!("Invalid json in: \r\n{}", new_text))?;
             }
 
-            ssm.create_parameter(&Param::new(name, new_text)).await?;
+            let param = Param::new(name, new_text);
+            ssm.create_parameter(&param).await?;
 
-            println!("Successfully created `{}`", name);
+            println!("Successfully created `{}`", param.name);
 
             Ok(())
         }

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,0 +1,10 @@
+pub struct Param {
+    pub name: String,
+    pub value: String,
+}
+
+impl Param {
+    pub fn new(name: String, value: String) -> Self {
+        Self { name, value }
+    }
+}

--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -25,7 +25,7 @@ impl Ssm {
     }
 
     pub async fn create_parameter(&self, param: &Param) -> Result<(), Error> {
-        let result = self
+        self
             .client
             .put_parameter()
             .name(&param.name)

--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -1,5 +1,7 @@
+use crate::param::Param;
 use anyhow::anyhow;
 use aws_sdk_ssm::{config::Region, Client, Error};
+use aws_sdk_ssm::types::ParameterType::SecureString;
 
 pub struct Ssm {
     client: Client,
@@ -20,6 +22,19 @@ impl Ssm {
         Self {
             client: Client::new(&config),
         }
+    }
+
+    pub async fn create_parameter(&self, param: &Param) -> Result<(), Error> {
+        let result = self
+            .client
+            .put_parameter()
+            .name(&param.name)
+            .value(&param.value)
+            .r#type(SecureString)
+            .send()
+            .await?;
+
+        Ok(())
     }
 
     pub async fn get_parameter_names(&self) -> Result<Vec<String>, Error> {


### PR DESCRIPTION
Adds a new "create" command for creating parameters. For now, only the creation of SecureString parameters is supported.

Part of doing this work involved refactoring the main function to not assume all commands start by selecting an existing parameter.