### PR TITLE
feat: add delete ssm parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ A note on region:
 Usage: parms [OPTIONS] <COMMAND>
 
 Commands:
-fetch Fetches the value of selected parameter
-edit  Allows to edit the current value of selected parameter
-help  Print this message or the help of the given subcommand(s)
+  create  Creates a new parameter
+  fetch   Fetches the value of selected parameter
+  edit    Allows to edit the current value of selected parameter
+  delete  Delete a parameter
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
--r, --region <REGION>  Search in this AWS region
--h, --help Print help
--V, --version Print version
+  -r, --region <REGION>  Search in this AWS region
+  -h, --help             Print help
+  -V, --version          Print version
 ```
 

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -1,4 +1,3 @@
-use std::io::{self, Write};
 use crate::param::Param;
 use crate::ssm::Ssm;
 use anyhow::bail;
@@ -24,15 +23,4 @@ pub async fn select_param_value(ssm: &Ssm) -> anyhow::Result<Param> {
         .await?;
 
     Ok(Param::new(parameter_names.remove(selected_index), value))
-}
-
-pub fn confirm(prompt: String) -> bool {
-    print!("{} [y/N]: ", prompt);
-    io::stdout().flush().unwrap();
-
-    let mut input = String::new();
-    match io::stdin().read_line(&mut input) {
-        Ok(_) => matches!(input.trim().to_lowercase().as_str(), "y" | "yes"),
-        Err(_) => false,
-    }
 }

--- a/src/command_helpers.rs
+++ b/src/command_helpers.rs
@@ -1,3 +1,4 @@
+use std::io::{self, Write};
 use crate::param::Param;
 use crate::ssm::Ssm;
 use anyhow::bail;
@@ -23,4 +24,15 @@ pub async fn select_param_value(ssm: &Ssm) -> anyhow::Result<Param> {
         .await?;
 
     Ok(Param::new(parameter_names.remove(selected_index), value))
+}
+
+pub fn confirm(prompt: String) -> bool {
+    print!("{} [y/N]: ", prompt);
+    io::stdout().flush().unwrap();
+
+    let mut input = String::new();
+    match io::stdin().read_line(&mut input) {
+        Ok(_) => matches!(input.trim().to_lowercase().as_str(), "y" | "yes"),
+        Err(_) => false,
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,12 @@ enum Commands {
         #[arg(short, long)]
         skip_json_validation: bool,
     },
+    /// Delete a parameter
+    Delete {
+        /// The name of the parameter to delete
+        #[arg(short, long)]
+        name: String,
+    },
 }
 
 #[tokio::main]
@@ -94,6 +100,15 @@ async fn main() -> Result<()> {
 
             println!("Successfully updated `{}`", &param.value);
 
+            Ok(())
+        }
+        Commands::Delete {
+            name,
+        } => {
+            ssm.delete_parameter(&name).await?;
+            
+            println!("Successfully deleted `{}`", name);
+            
             Ok(())
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
-use crate::command_helpers::{confirm, select_param_value};
+use crate::command_helpers::select_param_value;
+use crate::param::Param;
 use crate::ssm::Ssm;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use dialoguer::Editor;
+use dialoguer::{Confirm, Editor};
 use serde_json::Value;
-use crate::param::Param;
 
 mod command_helpers;
 mod param;
@@ -101,7 +101,11 @@ async fn main() -> Result<()> {
         Commands::Delete => {
             let param = select_param_value(&ssm).await?;
 
-            if confirm(format!("Delete parameter `{}`?", &param.name)) {
+            let confirmation = Confirm::new()
+                .with_prompt(format!("Delete parameter `{}`?", &param.name))
+                .interact()?;
+
+            if confirmation {
                 ssm.delete_parameter(&param.name).await?;
                 println!("Successfully deleted `{}`", param.name);
             } else {

--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -37,6 +37,17 @@ impl Ssm {
         Ok(())
     }
 
+    pub async fn delete_parameter(&self, parameter_name: &str) -> Result<(), Error> {
+        self
+            .client
+            .delete_parameter()
+            .name(parameter_name)
+            .send()
+            .await?;
+
+        Ok(())
+    }
+
     pub async fn get_parameter_names(&self) -> Result<Vec<String>, Error> {
         let paged_response: Result<Vec<_>, _> = self
             .client


### PR DESCRIPTION
Add a new subcommand that allows for the deletion of ssm parameters by name.

```
parms delete
```

You will be prompted to select an existing parameter.  Select one that is safe to delete.

A confirmation prompt will be displayed.  Press y|Y to proceed.  Any other key will abort the deletion.

```
✔ Select parameter (type for fuzzy search): · delete-me-param
Delete parameter `delete-me-param`? [y/N]: y
Successfully deleted `delete-me-param`
```
